### PR TITLE
Add table reports

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -37,7 +37,7 @@ class EmployeesController < ApplicationController
   private
 
   def employee_params
-    params.require(:employee).permit(:employee_number, :name_employee, :email_employee, :position_employee, :attendance_date)#, :administrator_id)
+    params.require(:employee).permit(:employee_number, :name_employee, :email_employee, :position_employee)#, :administrator_id)
   end
 
   def set_employees

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,2 @@
+class Report < ApplicationRecord
+end

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -19,11 +19,6 @@
     <%= employee.label :position_employee, class: "form-label"%>
     <%= employee.text_field :position_employee, class: "form-control"%>
   </div>
-
-  <div class="form-group">
-    <%= employee.label :attendance_date, class: "form-label"%>
-    <%= employee.text_field :attendance_date, class: "form-control", type:"date"%>
-  </div>
   
   <%= employee.submit "Save", class: "btn btn-success"%>
 

--- a/db/migrate/20210720221019_create_reports.rb
+++ b/db/migrate/20210720221019_create_reports.rb
@@ -1,0 +1,14 @@
+class CreateReports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reports do |t|
+      t.datetime :check_in
+      t.datetime :check_out
+      t.belongs_to :employee, foreign_key: true
+      
+
+
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_15_213909) do
+ActiveRecord::Schema.define(version: 2021_07_20_221019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,16 @@ ActiveRecord::Schema.define(version: 2021_07_15_213909) do
     t.index ["administrator_id"], name: "index_employees_on_administrator_id"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.datetime "check_in"
+    t.datetime "check_out"
+    t.bigint "administrator_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["administrator_id"], name: "index_reports_on_administrator_id"
+  end
+
   add_foreign_key "companies", "administrators"
   add_foreign_key "employees", "administrators"
+  add_foreign_key "reports", "administrators"
 end

--- a/test/fixtures/reports.yml
+++ b/test/fixtures/reports.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  check_in: 2021-07-20 17:10:19
+  check_out: 2021-07-20
+
+two:
+  check_in: 2021-07-20 17:10:19
+  check_out: 2021-07-20

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReportTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
A table called reports was added with the check in and check out fields.
This table will serve to keep a record of attendance and to generate attendance reports.
The form was also modified to add and edit employees removing the field assistances. Since the assists will be handled in a single table, it is not necessary for this field to be in the form.

This task was carried out in order to start working with the assistance functionality.

resolve #32 

